### PR TITLE
restructure api, unwrap should just unwrap

### DIFF
--- a/tests/unwrap_test.py
+++ b/tests/unwrap_test.py
@@ -3,22 +3,25 @@ from __future__ import unicode_literals
 import sure
 import json
 
-from unwrapper import unwrap, unwrap_raw,  CannotFindJsonBoundaryError
+from unwrapper import unwrap, unwrap_raw, unwrap_and_load, CannotFindJsonBoundaryError
 
 
 def test_basic_unwrap():
-    # z = unwrap(u'null({"result":ERROR})')
-    unwrap('json13123({"a":1, "b": 2, "c": 3})').should.equal(json.loads('{"a":1, "b": 2, "c": 3}'))
+    unwrap('json13123({"a":1, "b": 2, "c": 3})').should.equal('{"a":1, "b": 2, "c": 3}')
 
 
 def test_unwrap_list():
-    unwrap('json13123([{"a":1, "b": 2, "c": 3}, {"d":1, "e": 2, "f": 3}])').should.equal(json.loads('[{"a":1, "b": 2, "c": 3}, {"d":1, "e": 2, "f": 3}]'))
-    x = unwrap('json13123([{"a":1, "b": 2, "c": 3}, {"d":1, "e": 2, "f": 3}])')
+    unwrap('json13123([{"a":1, "b": 2, "c": 3}, {"d":1, "e": 2, "f": 3}])').should.equal('[{"a":1, "b": 2, "c": 3}, {"d":1, "e": 2, "f": 3}]')
+    x = json.loads(unwrap('json13123([{"a":1, "b": 2, "c": 3}, {"d":1, "e": 2, "f": 3}])'))
     assert x[0]["a"] == 1
 
 
 def test_unwrap_raw():
     unwrap_raw('json13123([{"a":1, "b": 2, "c": 3}, {"d":1, "e": 2, "f": 3}])').should.equal('[{"a":1, "b": 2, "c": 3}, {"d":1, "e": 2, "f": 3}]')
+
+
+def test_unwrap_and_load():
+    unwrap_and_load('json13123({"a":1, "b": 2, "c": 3})').should.equal(json.loads('{"a":1, "b": 2, "c": 3}'))
 
 
 def test_unwrap_invalid_inputs():

--- a/unwrapper/__init__.py
+++ b/unwrapper/__init__.py
@@ -1,3 +1,3 @@
-from .application import unwrap, unwrap_raw, CannotFindJsonBoundaryError
+from .application import unwrap, unwrap_raw, unwrap_and_load, CannotFindJsonBoundaryError
 
 VERSION = '0.0.8'

--- a/unwrapper/application.py
+++ b/unwrapper/application.py
@@ -6,14 +6,16 @@ import json
 
 class CannotFindJsonBoundaryError(Exception):
     def __init__(self):
-        Exception.__init__(self, "Could not find valid start/ending JSON boundaries-- most likely invalid JSON") 
+        Exception.__init__(self, "Could not find valid start/ending JSON boundaries-- most likely invalid JSON")
 
-def unwrap(content):
+
+def unwrap_and_load(content):
     """ unwraps the callback and loads the JSON into a dict
     """
-    return json.loads(unwrap_raw(content))
+    return json.loads(unwrap(content))
 
-def unwrap_raw(content):
+
+def unwrap(content):
     """ unwraps the callback and returns the raw content
     """
     starting_symbol = get_start_symbol(content)
@@ -21,6 +23,13 @@ def unwrap_raw(content):
     start = content.find(starting_symbol, 0)
     end = content.rfind(ending_symbol)
     return content[start:end+1]
+
+
+def unwrap_raw(content):
+    """ unwraps the callback and returns the raw content
+    """
+    return unwrap(content)
+
 
 def get_start_symbol(content):
     if content.find('[') > 0 and content.find('[') < content.find('{'):


### PR DESCRIPTION
- So far it seems that most people have been using `unwrap_raw` more often than
  `unwrap`. 
- Really, the default behavior should just be to unwrap the
  string, not necessarily loading it up into a dict.
- The API still includes an `unwrap_raw` definition (so that any existing code calling this function does not break) 
- I have added a new function, `unwrap_and_load` (I hate the name), that
  will call json.loads() on the unwrapped json.

@lucascarvalho @thedooner64 -- I know both of you are using this tool, do you guys have any thoughts on these changes?
